### PR TITLE
ignore warnings during database building using Python warnings API

### DIFF
--- a/cctrial/smart.py
+++ b/cctrial/smart.py
@@ -4,6 +4,7 @@ import traceback
 import os
 import pkgutil
 import inspect
+import warnings
 import StringIO
 from importlib import import_module
 from twisted.trial import runner
@@ -18,13 +19,10 @@ class SmartDB(object):
         self.testsDefinedPerFile = {}
         self.modulePerFile = {}
 
-        # remove any DeprecationWarnings due to inspect
-        old_stderr = sys.stderr
-        sys.stderr = StringIO.StringIO()
-        try:
+        # remove any warnings due to inspect
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             self.buildSmartDB(suite)
-        finally:
-            sys.stderr = old_stderr
 
     def stripPyc(self, fn):
         if fn.endswith(".pyc"):


### PR DESCRIPTION
Python warnings can not only print message to stderr, but also terminate
program if 'error' filter is set for warning category.
Using warnings.catch_warnings() allows to ignore all side effects of
warning emitting.

In Buildbot's bug 2340 I treat all not catched deprecation warnings as errors, which lead to this issue when I use cctrial.
